### PR TITLE
Anomaly detection boilerplate

### DIFF
--- a/demo/saner_2024_paper/t4_ano_detect_comparison.py
+++ b/demo/saner_2024_paper/t4_ano_detect_comparison.py
@@ -52,7 +52,7 @@ import warnings
 from sklearn.exceptions import ConvergenceWarning
 warnings.filterwarnings("ignore", category=ConvergenceWarning)
 #Disable unsupervised
-disable = ["train_IsolationForest", "train_LOF", "train_KMeans", "train_OneClassSVM", "train_RarityModel"]
+disable = {"train_IsolationForest", "train_LOF", "train_KMeans", "train_OneClassSVM", "train_RarityModel"}
 #Need a loop to run these multiple times
 sad = AnomalyDetector(store_scores=True, print_scores=False)
 

--- a/loglead/anomaly_detection.py
+++ b/loglead/anomaly_detection.py
@@ -170,7 +170,7 @@ class AnomalyDetector:
         return df_seq 
        
     def train_LR(self, max_iter=4000, tol=0.0003):
-        self.train_model(LogisticRegression, max_iter=max_iter)
+        self.train_model(LogisticRegression, max_iter=max_iter, tol=tol)
     
     def train_DT(self):
         self.train_model(DecisionTreeClassifier)
@@ -187,7 +187,8 @@ class AnomalyDetector:
         #LOF novelty=True model needs to be trained without anomalies
         #If we set novelty=False then Predict is no longer available for calling.
         #It messes up our general model prediction routine
-        self.train_model(LocalOutlierFactor, filter_anos=filter_anos, n_neighbors=n_neighbors,  contamination=contamination, novelty=True)
+        self.train_model(LocalOutlierFactor, filter_anos=filter_anos, n_neighbors=n_neighbors,
+                         max_samples=max_samples, contamination=contamination, novelty=True)
     
     def train_KMeans(self):
         self.train_model(KMeans, n_init="auto", n_clusters=2)

--- a/loglead/anomaly_detection.py
+++ b/loglead/anomaly_detection.py
@@ -121,11 +121,6 @@ class AnomalyDetector:
         self.filter_anos = filter_anos
         self.model.fit(X_train_to_use, self.labels_train)
 
-    #def dep_train_model(self, df_seq, model):
-    #    X_train, labels = self._prepare_data(train=True, df_seq=df_seq)
-    #    self.model = model
-    #    self.model.fit(X_train, labels)
-    
     def predict(self, custom_plot=False):
         #Binary scores
         X_test_to_use = self.X_test_no_anos if self.filter_anos else self.X_test
@@ -215,20 +210,18 @@ class AnomalyDetector:
         
     def evaluate_all_ads(self, disabled_methods=None):
         if disabled_methods is None:
-            disabled_methods = []
-        for method_name in sorted(dir(self)):
-            if (method_name.startswith("train_")
-                    and not method_name.startswith("train_model")
-                    and method_name not in disabled_methods):
-                method = getattr(self, method_name)
-                if callable(method):
-                    if not self.print_scores:
-                        print(f"Running {method_name}")
-                    time_start = time.time()
-                    method()
-                    self.predict()
-                    if self.print_scores:
-                        print(f'Total time: {time.time()-time_start:.2f} seconds')
+            disabled_methods = set()
+        train_methods = {getattr(self, m) for m in dir(self) if m.startswith('train_') and m not in disabled_methods
+                         and callable(getattr(self, m))}
+        train_methods.discard(self.train_model)
+        for method in train_methods:
+            if self.print_scores:
+                print(f"Running {method}")
+            time_start = time.time()
+            method()
+            self.predict()
+            if self.print_scores:
+                print(f'Total time: {time.time()-time_start:.2f} seconds')
         if self.print_scores:
             print("---------------------------------------------------------------")
 

--- a/loglead/anomaly_detection.py
+++ b/loglead/anomaly_detection.py
@@ -215,7 +215,7 @@ class AnomalyDetector:
                          and callable(getattr(self, m))}
         train_methods.discard(self.train_model)
         for method in train_methods:
-            if self.print_scores:
+            if not self.print_scores:
                 print(f"Running {method}")
             time_start = time.process_time()
             method()

--- a/loglead/anomaly_detection.py
+++ b/loglead/anomaly_detection.py
@@ -211,7 +211,7 @@ class AnomalyDetector:
                 len_col = "e_event_id_len" #item list col has the parser name when using events, but length doesn't
             else:
                 len_col = self.item_list_col+"_len"
-        self.train_model(OOV_detector, filter_anos=filter_anos, len_col=len_col, df=self.test_df, threshold=threshold)
+        self.train_model(OOV_detector, filter_anos=filter_anos, len_col=len_col, test_df=self.test_df, threshold=threshold)
         
     def evaluate_all_ads(self, disabled_methods=None):
         if disabled_methods is None:

--- a/loglead/anomaly_detection.py
+++ b/loglead/anomaly_detection.py
@@ -183,12 +183,12 @@ class AnomalyDetector:
         self.train_model(IsolationForest, filter_anos=filter_anos,
                          n_estimators=n_estimators, max_samples=max_samples, contamination=contamination)
                           
-    def train_LOF(self, n_neighbors=20, max_samples='auto', contamination="auto", filter_anos=True):
+    def train_LOF(self, n_neighbors=20, contamination="auto", filter_anos=True):
         #LOF novelty=True model needs to be trained without anomalies
         #If we set novelty=False then Predict is no longer available for calling.
         #It messes up our general model prediction routine
         self.train_model(LocalOutlierFactor, filter_anos=filter_anos, n_neighbors=n_neighbors,
-                         max_samples=max_samples, contamination=contamination, novelty=True)
+                         contamination=contamination, novelty=True)
     
     def train_KMeans(self):
         self.train_model(KMeans, n_init="auto", n_clusters=2)

--- a/loglead/anomaly_detection.py
+++ b/loglead/anomaly_detection.py
@@ -111,7 +111,7 @@ class AnomalyDetector:
 
         return X, labels    
         
-    def train_model(self, model, filter_anos=False, **model_kwargs):
+    def train_model(self, model,  /, *, filter_anos=False, **model_kwargs):
         X_train_to_use = self.X_train_no_anos if filter_anos else self.X_train
         #Store the current the model and whether it uses ano data or no
         if isclass(model):

--- a/loglead/anomaly_detection.py
+++ b/loglead/anomaly_detection.py
@@ -1,4 +1,5 @@
 import time
+from inspect import isclass
 
 import polars as pl
 import numpy as np
@@ -113,7 +114,10 @@ class AnomalyDetector:
     def train_model(self, model, filter_anos=False, **model_kwargs):
         X_train_to_use = self.X_train_no_anos if filter_anos else self.X_train
         #Store the current the model and whether it uses ano data or no
-        self.model = model(**model_kwargs)
+        if isclass(model):
+            self.model = model(**model_kwargs)
+        else:
+            self.model = model  # Backwards compatibility with previous implementation
         self.filter_anos = filter_anos
         self.model.fit(X_train_to_use, self.labels_train)
 

--- a/loglead/anomaly_detection.py
+++ b/loglead/anomaly_detection.py
@@ -217,11 +217,11 @@ class AnomalyDetector:
         for method in train_methods:
             if self.print_scores:
                 print(f"Running {method}")
-            time_start = time.time()
+            time_start = time.process_time()
             method()
             self.predict()
             if self.print_scores:
-                print(f'Total time: {time.time()-time_start:.2f} seconds')
+                print(f'Total time: {time.process_time()-time_start:.2f} seconds')
         if self.print_scores:
             print("---------------------------------------------------------------")
 

--- a/tests/anomaly_detectors.py
+++ b/tests/anomaly_detectors.py
@@ -35,11 +35,11 @@ for dataset in datasets:
     df = pl.read_parquet(primary_file)
 
     for col in cols_event:
-        disabled_methods = []
-        disabled_methods.append("train_LOF") #Too slow. Disabled to make tests run faster
-        disabled_methods.append("train_OneClassSVM") #Too slow. Disabled to make tests run faster
+        disabled_methods = set()
+        disabled_methods.add("train_LOF") #Too slow. Disabled to make tests run faster
+        disabled_methods.add("train_OneClassSVM") #Too slow. Disabled to make tests run faster
         if col == "m_message":
-            disabled_methods.append("train_OOVDetector")
+            disabled_methods.add("train_OOVDetector")
           #Only run if the predictor column AND anomaly labels are present AND we have at least two classes in the data
         if (col in df.columns and "anomaly" in df.columns and 
         df["normal"].sum() > 10 and
@@ -55,11 +55,11 @@ for dataset in datasets:
         df_seq = pl.read_parquet(seq_file)
         print(f"Running seqeuence anomaly detectors with {seq_file}")
         for col in cols_event:
-            disabled_methods = []
-            disabled_methods.append("train_LOF") #Too slow. Disabled to make tests run faster
-            disabled_methods.append("train_OneClassSVM") #Too slow. Disabled to make tests run faster
+            disabled_methods = set()
+            disabled_methods.add("train_LOF") #Too slow. Disabled to make tests run faster
+            disabled_methods.add("train_OneClassSVM") #Too slow. Disabled to make tests run faster
             if col == "m_message":
-                disabled_methods.append("train_OOVDetector")
+                disabled_methods.add("train_OOVDetector")
                 #Only run if the predictor column AND anomaly labels are present AND we have at least two classes in the data
             if (col in df.columns and "anomaly" in df.columns and 
             df["normal"].sum() > 10 and
@@ -77,6 +77,6 @@ for dataset in datasets:
             sad = AnomalyDetector(numeric_cols = numeric_cols, print_scores= False, store_scores=True)
             #High training fraction to ensure we always have suffiecient samples as these are reduced dataframes 
             sad.test_train_split (df_seq, test_frac=0.2) 
-            sad.evaluate_all_ads(disabled_methods=[])        
+            sad.evaluate_all_ads()
 
 print("Anomaly detectors test complete.")


### PR DESCRIPTION
Fixes #15 
Only accept this PR after closing #18.

Many `train_MODEL` functions in `AnomalyDetection` are refactored away.
Instead, a single function `train_model` accepts a model class and keyword arguments that should be passed to the model constructor.
`train_model` populates the keyword arguments with the default values that were used in `train_MODEL` functions.
This allows to pass any model to the `AnomalyDetection` class, as well as give any kwargs to models that were already implemented before.

