### PR TITLE
Drain persistence

### DIFF
--- a/demo/Drain_Persistence.py
+++ b/demo/Drain_Persistence.py
@@ -1,0 +1,143 @@
+import os
+import polars as pl
+
+from loglead.enhancers import EventLogEnhancer
+
+
+def run_experiment(n_parts=10):
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    os.chdir(script_dir)
+    # Location of our sample data
+    sample_data = os.path.join(script_dir, 'samples')
+
+    # Load TB (Thunderbird) data from sample data
+    df_full = pl.read_parquet(os.path.join(sample_data, "tb_0125percent.parquet"))
+    print(f"Loaded dataset with {df_full.shape[0]} rows")
+
+    # Split into n parts
+    chunk_size = df_full.shape[0] // n_parts
+    chunks = [df_full[i*chunk_size:(i+1)*chunk_size] for i in range(n_parts)]
+
+    # Start template mining
+    print("=" * 50)
+    print("NORMAL MODE")
+    print("=" * 50)
+    # --- Normal mode ---
+    for i, chunk in enumerate(chunks):
+        df_chunk = chunk.clone()
+
+        enhancer = EventLogEnhancer(df_chunk)
+        df_chunk = enhancer.normalize()
+        df_chunk = enhancer.parse_drain(reparse=True, templates=True)
+        templates_per_id = df_chunk.group_by("e_event_drain_id").agg(pl.col("e_event_drain_template"))
+        templates_per_id_dict = templates_per_id.to_dict(as_series=False)
+        template_id_mapping = dict(zip(templates_per_id_dict["e_event_drain_id"], templates_per_id_dict["e_event_drain_template"]))
+
+        print("-" * 50)
+        print(f"Log chunk {i+1}")
+        print("-" * 50)
+        print(f"Number of clusters: {len(template_id_mapping.keys())}")
+        print(f"Templates for the first five clusters (e1, e2, e3, e4, and e5):")
+        # In normal mode, each chunk starts with a fresh miner.
+        # Because the size of log chunk is not that large,
+        # clusters from 'e1' to 'e5' always exist,
+        # but their content might chance between runs.
+        try:
+            print(max(template_id_mapping['e1'], key=lambda t: t.count("*")))
+        
+        except Exception: KeyError (
+            print("Templates not found. Cluster 'e1' have been pruned.")
+        )
+        try:
+            print(max(template_id_mapping['e2'], key=lambda t: t.count("*")))
+        
+        except Exception: KeyError (
+            print("Templates not found. Cluster 'e2' have been pruned.")
+        )        
+        try:
+            print(max(template_id_mapping['e3'], key=lambda t: t.count("*")))
+        
+        except Exception: KeyError (
+            print("Templates not found. Cluster 'e3' have been pruned.")
+        )        
+        try:
+            print(max(template_id_mapping['e4'], key=lambda t: t.count("*")))
+        
+        except Exception: KeyError (
+            print("Templates not found. Cluster 'e4' have been pruned.")
+        )        
+        try:
+            print(max(template_id_mapping['e5'], key=lambda t: t.count("*")))
+        
+        except Exception: KeyError (
+            print("Templates not found. Cluster 'e5' have been pruned.")
+        )
+    print("=" * 50)
+    print("PERSISTENCE MODE")
+    print("=" * 50)
+
+    # --- Persistence mode ---
+    for i, chunk in enumerate(chunks):
+        df_chunk = chunk.clone()
+
+        enhancer = EventLogEnhancer(df_chunk)
+        df_chunk = enhancer.normalize()
+        df_chunk = enhancer.parse_drain(reparse=True, templates=True, persistence=True)
+        templates_per_id = df_chunk.group_by("e_event_drain_id").agg(pl.col("e_event_drain_template"))
+        templates_per_id_dict = templates_per_id.to_dict(as_series=False)
+        template_id_mapping = dict(zip(templates_per_id_dict["e_event_drain_id"], templates_per_id_dict["e_event_drain_template"]))
+        
+        print("-" * 50)
+        print(f"Log chunk {i+1}")
+        print("-" * 50)
+        print(f"Number of clusters: {len(template_id_mapping.keys())}")
+        print(f"Templates for the first five clusters (e1, e2, e3, e4, and e5):")
+        # Miner state is carried across chunks.
+        # If the same log pattern shows up later,
+        # it’s matched to its original cluster (e1, e2, e3, etc.).
+        # In persistence mode, log processing runs longer, which increases
+        # the possibility of pruning or merging clusters.
+        try:
+            print(max(template_id_mapping['e1'], key=lambda t: t.count("*")))
+        
+        except Exception: KeyError (
+            print("Templates not found. Cluster 'e1' have been pruned.")
+        )
+        try:
+            print(max(template_id_mapping['e2'], key=lambda t: t.count("*")))
+        
+        except Exception: KeyError (
+            print("Templates not found. Cluster 'e2' have been pruned.")
+        )        
+        try:
+            print(max(template_id_mapping['e3'], key=lambda t: t.count("*")))
+        
+        except Exception: KeyError (
+            print("Templates not found. Cluster 'e3' have been pruned.")
+        )        
+        try:
+            print(max(template_id_mapping['e4'], key=lambda t: t.count("*")))
+        
+        except Exception: KeyError (
+            print("Templates not found. Cluster 'e4' have been pruned.")
+        )        
+        try:
+            print(max(template_id_mapping['e5'], key=lambda t: t.count("*")))
+        
+        except Exception: KeyError (
+            print("Templates not found. Cluster 'e5' have been pruned.")
+        )
+    
+    # Clean up
+    if os.path.exists("drain3_state_no_masking.json"):
+        os.remove("drain3_state_no_masking.json")
+
+    return
+
+
+if __name__ == "__main__":
+    # If the state file exists, remove it to prevent
+    # any unexpected side effects to demo.
+    if os.path.exists("drain3_state_no_masking.json"):
+        os.remove("drain3_state_no_masking.json")
+    run_experiment()

--- a/loglead/parsers/__init__.py
+++ b/loglead/parsers/__init__.py
@@ -1,5 +1,6 @@
 __all__ = ['AELParser', 'BrainParser', 'IPLoMParser', 'LenmaTemplateManager', 'PL_IPLoMParser',
-           'SpellParser', 'DrainTemplateMiner', 'DrainTemplateMinerNoMasking']
+           'SpellParser', 'DrainTemplateMiner', 'DrainTemplateMinerNoMasking',
+           'DrainPersistenceTemplateMiner', 'DrainPersistenceTemplateMinerNoMasking']
 import logging
 from .AEL.AEL import AELParser
 try:
@@ -8,7 +9,7 @@ try:
 except Exception as e:
     logging.warning(f"Could not import BertEmbeddings because of: {e}")
 from .Brain.Brain import BrainParser
-from .drain3.drain import DrainTemplateMiner, DrainTemplateMinerNoMasking
+from .drain3.drain import DrainTemplateMiner, DrainTemplateMinerNoMasking, DrainPersistenceTemplateMiner, DrainPersistenceTemplateMinerNoMasking
 from .iplom.IPLoM import IPLoMParser
 from .lenma.lenma import LenmaTemplateManager
 from .pl_iplom.pl_iplom import PL_IPLoMParser

--- a/loglead/parsers/drain3/drain.py
+++ b/loglead/parsers/drain3/drain.py
@@ -1,9 +1,11 @@
 import os.path
 
 from drain3 import TemplateMiner
+from drain3.file_persistence import FilePersistence
 from drain3.template_miner_config import TemplateMinerConfig
 
-__all__ = ['DrainTemplateMiner', 'DrainTemplateMinerNoMasking']
+__all__ = ['DrainTemplateMiner', 'DrainTemplateMinerNoMasking',
+           'DrainPersistenceTemplateMiner', 'DrainPersistenceTemplateMinerNoMasking']
 
 current_script_path = os.path.abspath(__file__)
 current_script_directory = os.path.dirname(current_script_path)
@@ -12,7 +14,14 @@ tmc = TemplateMinerConfig()
 tmc.load(ini_location)
 DrainTemplateMiner = TemplateMiner(config=tmc)
 
+persistence = FilePersistence('drain3_state.json')
+DrainPersistenceTemplateMiner = TemplateMiner(persistence, config=tmc)
+
+
 ini_location = os.path.join(current_script_directory, 'drain3_no_masking.ini')
 tmc = TemplateMinerConfig()
 tmc.load(ini_location)
 DrainTemplateMinerNoMasking = TemplateMiner(config=tmc)
+
+persistence_no_masking = FilePersistence('drain3_state_no_masking.json')
+DrainPersistenceTemplateMinerNoMasking = TemplateMiner(persistence_no_masking, config=tmc)


### PR DESCRIPTION
Drain persistence mode added as an additional parameter option to `parse_drain()` function of `EventLogEnhancer`. 

When persistence mode is enabled by calling `parse_drain(persistence=True)`, the parser saves the state of log processing and template clustering into a file. The file is created in the same directory where the function is executed, and it allows subsequent runs of the parser to continue from the previously saved state rather than starting from scratch. This makes it possible to reuse and extend existing clusters across sessions.

To prevent runtime issues, users are advised to ensure that all null values are removed from the data frame before parsing when persistence mode is in use. If persistence mode is used multiple times for different purposes, the same state file will be reused. In such cases, the file should be deleted manually before re-running the parser to avoid unintended effects on template formation.

A demonstration of persistence mode is provided in `LogLead/demo/Drain_Persistence.py`. The demo can be executed with the following commands:
```
cd LogLead/demo
python Drain_Persistence.py
```
The demo uses TB (Thunderbird) sample data to highlight the differences between normal and persistence modes. In normal mode, log processing starts always from scratch, whereas in persistence mode, previously saved state information serves as the basis for template clustering, allowing the process to build on earlier results. Because parsing in persistence mode can run longer and accumulate history, the possibility of pruning/merging clusters increases, as the demo shows.