### PR TITLE
Feature/line distance matching

### DIFF
--- a/demo/mcp_demo.py
+++ b/demo/mcp_demo.py
@@ -295,13 +295,16 @@ def run_demo(log_root_path, keep_cache=False, folder_names_path=None, format="au
                                        target_files=2, content_format="Words")
     show(res, ["file_name", "comparison_folder", "cosine", "zscore_sum"])
 
-    banner("L4 distance_line_content -- the actual diff")
-    res = server.distance_line_content("demo", target, comparison_folders=1,
-                                       target_files=1, max_changed_lines=3)
-    for comp in res["comparisons"]:
-        print(f"   {comp['file_name']} vs {comp['comparison_folder']}: {comp['summary']}")
-        for line in comp["changed_sample"]:
-            print(f"     {line['difference']} {line['content'][:80]}")
+    banner("L4 distance_line_content -- which kinds of line are new here?")
+    res = server.distance_line_content("demo", target, comparison_folders=3,
+                                       target_files=1)
+    for entry in res["files"]:
+        for row in entry["resolutions"]:
+            print(f"   {entry['file_name']} @ {row['resolution']}: "
+                  f"{row['buckets']} buckets, {row['target_only_buckets']} target-only "
+                  f"({row['target_only_pct']:.2f}% of lines)")
+    show(res, ["resolution", "target_pct", "comparison_pct", "target_only",
+               "representative_line"])
 
     # ------------------------------------------------------------- anomaly --
     banner("L1 anomaly_folder_filename -- score log folders by their file sets")

--- a/loglead/delta/distance.py
+++ b/loglead/delta/distance.py
@@ -6,8 +6,8 @@ Four functions, mirroring LogDelta's config step names:
   names* only. Never opens a file.
 * ``distance_folder_content``  -- log folder vs log folder over log *text*.
 * ``distance_file_content``    -- file vs same-named file, across log folders.
-* ``distance_line_content``    -- line-by-line diff of one file across log
-  folders.
+* ``distance_line_content``    -- bucket-histogram comparison of one file's
+  lines against the same file in the comparison log folders.
 
 Every function returns a ``pl.DataFrame`` and writes nothing. All measures are
 **distances**, so larger means more different, and 0 means identical.
@@ -21,6 +21,7 @@ for the comparison). Narrowing weakens ``rank_sum``/``zscore_sum`` the same way
 narrowing ``detectors`` does for the anomaly tools.
 """
 
+import numpy as np
 import polars as pl
 
 from .. import LogDistance
@@ -186,53 +187,220 @@ def distance_file_content(
     return pl.DataFrame(results), df
 
 
+#: Bucket resolutions to run when the caller names none, coarse first. Both are
+#: near-free, so the pair runs on every call.
+#:
+#: ``Minhash-<tokenizer>`` and ``Parse-<Algorithm>`` are valid resolutions but
+#: are left out of the default: both are a second pass over what the first one
+#: flagged. Measured on 94k BGL lines, ``Minhash-words`` costs about 2x the pair
+#: above and ``Minhash-3gram`` about 10x. ``Parse-Drain`` is slower again, and
+#: its template ids are not stable while ``max_clusters`` eviction is enabled in
+#: ``drain3.ini``.
+DEFAULT_RESOLUTIONS = ("Prefix-3", "Exact")
+
+
+def _resolution_format(resolution):
+    """Resolution name -> ``content_format``. ``Exact`` is the masked line itself."""
+    return "Sklearn" if resolution == "Exact" else resolution
+
+
+def _bucket_label(schema, field):
+    """One string per row to group on: a token list is joined, a scalar cast."""
+    if schema[field] == pl.List(pl.Utf8):
+        return pl.col(field).list.join(" ")
+    return pl.col(field).cast(pl.Utf8, strict=False)
+
+
+def _divergences(bucket_df, target_lines, comparison_lines):
+    """Distribution distances between the target and comparison histograms."""
+    p = bucket_df.get_column("target_n").to_numpy() / target_lines
+    q = bucket_df.get_column("comparison_n").to_numpy() / comparison_lines
+    m = (p + q) / 2
+    # 0 log 0 is 0 here, so each side contributes only over its own support.
+    with np.errstate(divide="ignore", invalid="ignore"):
+        left = np.where(p > 0, p * np.log2(np.divide(p, m, where=m > 0)), 0.0)
+        right = np.where(q > 0, q * np.log2(np.divide(q, m, where=m > 0)), 0.0)
+    only = bucket_df.get_column("target_only").to_numpy()
+    return {
+        "n_buckets": bucket_df.height,
+        "n_target_only": int(only.sum()),
+        "target_only_mass": float(p[only].sum() * 100),
+        "js_divergence": float(0.5 * left.sum() + 0.5 * right.sum()),
+        "total_variation": float(0.5 * np.abs(p - q).sum()),
+        "target_lines": target_lines,
+        "comparison_lines": comparison_lines,
+    }
+
+
+def comparable_files(df, target_folder, comparison_folders="ALL", target_files="ALL"):
+    """File names the target log folder shares with at least one comparison one.
+
+    Files are matched by name across log folders, so a log root whose folders
+    share no file name has nothing to compare and this is empty. Cheap enough
+    to call before deciding whether to build a content representation at all.
+    """
+    target_df, comparison_folder_names = log_root.prepare_folders(
+        df, target_folder, comparison_folders
+    )
+    file_names = log_root.prepare_files(target_df, target_files)
+    shared = set(
+        df.filter(pl.col("folder").is_in(comparison_folder_names))
+        .get_column("file_name").unique().to_list()
+    )
+    return [name for name in file_names if name in shared]
+
+
+def _bucket_histogram(target_df, comparison_df, field, resolution):
+    """One row per bucket, with both sides' share of it."""
+    label = _bucket_label(target_df.schema, field)
+    target = (
+        target_df.select(label.alias("bucket"), "m_message")
+        .group_by("bucket")
+        .agg(pl.len().alias("target_n"),
+             pl.col("m_message").first().alias("representative_line"))
+    )
+    comparison = (
+        comparison_df.select(label.alias("bucket"), "m_message")
+        .group_by("bucket")
+        .agg(pl.len().alias("comparison_n"),
+             pl.col("m_message").first().alias("_comparison_line"))
+    )
+    n_target, n_comparison = target_df.height, comparison_df.height
+
+    buckets = (
+        target.join(comparison, on="bucket", how="full", coalesce=True)
+        .with_columns(pl.col("target_n").fill_null(0),
+                      pl.col("comparison_n").fill_null(0))
+        .with_columns(
+            pl.lit(resolution).alias("resolution"),
+            # A bucket only the comparison side has still needs a readable line.
+            pl.coalesce("representative_line", "_comparison_line")
+              .alias("representative_line"),
+            (pl.col("target_n") / n_target * 100).alias("target_pct"),
+            (pl.col("comparison_n") / n_comparison * 100).alias("comparison_pct"),
+        )
+        .with_columns(
+            (pl.col("target_pct") - pl.col("comparison_pct")).alias("delta_pct"),
+            (pl.col("comparison_n") == 0).alias("target_only"),
+        )
+        .select("resolution", "bucket", "representative_line",
+                "target_n", "target_pct", "comparison_n", "comparison_pct",
+                "delta_pct", "target_only")
+        # Target-only buckets first, then by how much of the target they hold:
+        # the planted-anomaly bucket outranks the singleton noise floor.
+        .sort(["target_only", "target_n", "delta_pct"], descending=[True, True, True])
+    )
+    return buckets, _divergences(buckets, n_target, n_comparison)
+
+
 def distance_line_content(
     df, target_folder, comparison_folders="ALL", target_files="ALL", mask=True,
+    resolutions=DEFAULT_RESOLUTIONS,
 ):
-    """Line-by-line diff of a file between the target log folder and others.
+    """Compare a file's distribution of line types against the same file elsewhere.
 
-    :returns: a list of ``(file_name, comparison_folder, diff_df)``. Each
-        ``diff_df`` has ``line_number``, ``difference`` (``' '`` unchanged,
-        ``'-'`` only in target, ``'+'`` only in comparison, ``'?'`` hint) and
-        ``content``.
+    Every line is bucketed by a cheap hash of its content, then the target's
+    bucket histogram is compared with the comparison log folders'. Buckets
+    holding target lines and no comparison lines are point anomalies; buckets
+    present on both sides at very different rates are distribution shifts,
+    which a nearest-neighbour distance could not see at all.
+
+    The comparison log folders are pooled into one baseline, so ``target_only``
+    means "absent from every comparison log folder", not from one of them.
+
+    :param resolutions: bucket granularities, **coarse first**. A coarse
+        resolution such as ``Prefix-3`` absorbs benign variation and so carries a
+        lower false-positive floor, but is blind to anomalies that differ only
+        late in the line; ``Exact`` is never blind but is noisier. Running both
+        is cheap, and the coarsest resolution that flags a bucket is the
+        strength of the evidence. Accepts any ``content_format``, plus
+        ``"Exact"`` for the masked line.
+
+        ``Minhash-<tokenizer>`` buckets by similarity rather than by position,
+        so unlike ``Prefix-3`` it is not blind to a late-line anomaly and unlike
+        ``Exact`` it tolerates masking that missed a parameter. It absorbs
+        probabilistically -- two lines share a bucket with probability
+        ``J ** rows`` -- so a bucket it does not flag is weaker evidence than
+        one a deterministic resolution does not flag. Opt in; see
+        :data:`DEFAULT_RESOLUTIONS` for the cost.
+    :returns: ``(per_file, summary_df, df)``. ``per_file`` is a list of
+        ``(target_folder, file_name, bucket_df)``, one entry per file present in
+        both the target and at least one comparison log folder; ``summary_df``
+        has one row per (file, resolution) with ``target_only_mass``,
+        ``js_divergence`` and ``total_variation``; ``df`` is the (possibly
+        enhanced) input frame, to be kept so a session avoids re-parsing.
     """
-    field = "e_message_normalized" if mask else "m_message"
-    if mask and field not in df.columns:
+    if not mask:
         raise ValueError(
-            "mask=True requires the log root to have been normalized. "
-            "Open the log root with mask=True."
+            "distance_line_content requires mask=True. On raw lines almost every "
+            "line is distinct, so nearly all of them fall into target-only "
+            "buckets and the histogram carries no signal."
+        )
+    resolutions = list(resolutions)
+    if not resolutions:
+        raise ValueError("At least one resolution is required.")
+
+    # Before materializing anything: prepare_content runs over the whole log
+    # root, while the analysis only ever reads files the target shares with a
+    # comparison log folder. On a log root where no name is shared -- ten slices
+    # of one split file, say -- that work would buy an empty result.
+    comparable = comparable_files(df, target_folder, comparison_folders, target_files)
+    if not comparable:
+        return [], pl.DataFrame(), df
+
+    fields = {}
+    for resolution in resolutions:
+        df, field = log_root.prepare_content(df, mask, _resolution_format(resolution))
+        fields[resolution] = field
+
+    # After prepare_content, so these views carry the resolution columns.
+    target_df, comparison_folder_names = log_root.prepare_folders(
+        df, target_folder, comparison_folders
+    )
+    comparison_df = df.filter(pl.col("folder").is_in(comparison_folder_names))
+
+    per_file, summaries = [], []
+    for file_name in comparable:
+        target_lines = target_df.filter(pl.col("file_name") == file_name)
+        comparison_lines = comparison_df.filter(pl.col("file_name") == file_name)
+        # No comparison log folder has a file of this name, so there is nothing
+        # to judge it against -- the same rule distance_file_content applies.
+        if target_lines.height == 0 or comparison_lines.height == 0:
+            continue
+
+        frames = []
+        for resolution in resolutions:
+            buckets, summary = _bucket_histogram(
+                target_lines, comparison_lines, fields[resolution], resolution
+            )
+            frames.append(buckets)
+            summaries.append({
+                "target_folder": target_folder,
+                "file_name": file_name,
+                "resolution": resolution,
+                "comparison_folders": " ".join(comparison_folder_names),
+                **summary,
+            })
+        per_file.append(
+            (target_folder, file_name, pl.concat(frames, how="vertical_relaxed"))
         )
 
-    target_df, comparison_folder_names = log_root.prepare_folders(df, target_folder, comparison_folders)
-    file_names = log_root.prepare_files(target_df, target_files)
-    other_folders_df = df.filter(pl.col("folder").is_in(comparison_folder_names))
-
-    diffs = []
-    for other_folder in comparison_folder_names:
-        other_folder_df = other_folders_df.filter(pl.col("folder") == other_folder)
-        for file_name in file_names:
-            target_file_df = target_df.filter(pl.col("file_name") == file_name)
-            other_file_df = other_folder_df.filter(pl.col("file_name") == file_name)
-            if other_file_df.height == 0:
-                continue
-            distance = LogDistance(target_file_df, other_file_df, field=field)
-            diffs.append((file_name, other_folder, distance.diff_lines()))
-
-    return diffs
+    return per_file, pl.DataFrame(summaries), df
 
 
-def summarize_diff(diff_df):
-    """Counts per ``difference`` marker, for a compact tool result."""
-    counts = (
-        diff_df.group_by("difference")
-        .agg(pl.len().alias("n"))
-        .to_dict(as_series=False)
+def summarize_line_buckets(bucket_df):
+    """Per-resolution counts for one file, for a compact tool result."""
+    return (
+        bucket_df.group_by("resolution", maintain_order=True)
+        .agg(
+            pl.len().alias("buckets"),
+            pl.col("target_only").sum().alias("target_only_buckets"),
+            pl.col("target_n").filter(pl.col("target_only")).sum()
+              .alias("target_only_lines"),
+            pl.col("target_n").sum().alias("target_lines"),
+        )
+        .with_columns(
+            (pl.col("target_only_lines") / pl.col("target_lines") * 100)
+            .alias("target_only_pct")
+        )
     )
-    by_marker = dict(zip(counts["difference"], counts["n"]))
-    return {
-        "unchanged": by_marker.get(" ", 0),
-        "only_in_target": by_marker.get("-", 0),
-        "only_in_comparison": by_marker.get("+", 0),
-        "hints": by_marker.get("?", 0),
-        "total": diff_df.height,
-    }

--- a/loglead/delta/log_root.py
+++ b/loglead/delta/log_root.py
@@ -35,6 +35,71 @@ CONTENT_FORMATS = ("Words", "3grams", "Sklearn", "File")
 #: resolved dynamically against :class:`EventLogEnhancer`.
 _PARSE_PREFIX = "Parse-"
 
+#TODO Lot of stuff about the line comparer in logroot. Clearn up needed
+#: The ``Prefix-<k>`` family: the first k words of a line, as one string. Built
+#: by ``EventLogEnhancer.words(prefixes=[k])`` in the same pass as ``e_words``.
+_PREFIX_PREFIX = "Prefix-"
+
+
+def _prefix_width(content_format):
+    """Parse the ``k`` out of ``Prefix-<k>``."""
+    raw = content_format.split("-", 1)[1]
+    if not raw.isdigit() or int(raw) < 1:
+        raise ValueError(
+            f"Prefix content format needs a positive word count, got {content_format!r}"
+        )
+    return int(raw)
+
+
+#: The ``Minhash-<tokenizer>`` family: one band of minhash values over a line's
+#: tokens, as one string. Built by ``EventLogEnhancer.minhash()``. Accepts
+#: optional ``-r<rows>`` and ``-s<seed>`` suffixes, e.g. ``Minhash-3gram-r6-s7``.
+_MINHASH_PREFIX = "Minhash-"
+
+#: Applied to a bare ``Minhash-<tokenizer>``. Fixed rather than random so a
+#: signature means the same thing across runs and across cached sessions.
+_MINHASH_DEFAULT_ROWS = 4
+_MINHASH_DEFAULT_SEED = 0
+
+
+def _minhash_config(content_format):
+    """Parse ``Minhash-<tokenizer>[-r<rows>][-s<seed>]`` into its three parts."""
+    parts = content_format.split("-")[1:]
+    tokenizer = parts[0].lower() if parts else ""
+    if tokenizer not in EventLogEnhancer.MINHASH_TOKENIZERS:
+        raise ValueError(
+            f"Unknown minhash tokenizer {tokenizer!r} in {content_format!r}. Valid "
+            f"options: {', '.join(sorted(EventLogEnhancer.MINHASH_TOKENIZERS))}."
+        )
+    rows, seed = _MINHASH_DEFAULT_ROWS, _MINHASH_DEFAULT_SEED
+    for part in parts[1:]:
+        key, value = part[:1].lower(), part[1:]
+        if key == "r" and value.isdigit() and int(value) >= 1:
+            rows = int(value)
+        elif key == "s" and value.isdigit():
+            seed = int(value)
+        else:
+            raise ValueError(
+                f"Unrecognized part {part!r} in {content_format!r}. Expected "
+                f"Minhash-<tokenizer>[-r<rows>][-s<seed>], e.g. 'Minhash-3gram-r4-s0'."
+            )
+    return tokenizer, rows, seed
+
+
+def _minhash_column(tokenizer, rows, seed):
+    return f"e_minhash_{tokenizer}_r{rows}_s{seed}"
+
+
+def minhash_formats(columns):
+    """``Minhash-`` format names for every minhash column in ``columns``.
+
+    The row count and seed live only in the column name, so this is how a
+    reopened session recovers which signatures a cached frame is carrying.
+    """
+    return sorted(_MINHASH_PREFIX + "-".join(column.split("_")[2:])
+                  for column in columns if column.startswith("e_minhash_"))
+
+
 #: How a log root may be read, keyed by name. ``"auto"`` detects the format per
 #: file; every other entry pins one format family for the whole log root.
 #:
@@ -927,11 +992,16 @@ def content_column(mask, content_format):
         return "file_name"
     if content_format == "Sklearn":
         return "e_message_normalized" if mask else "m_message"
+    if content_format.startswith(_PREFIX_PREFIX):
+        return f"e_words_prefix_{_prefix_width(content_format)}"
+    if content_format.startswith(_MINHASH_PREFIX):
+        return _minhash_column(*_minhash_config(content_format))
     if content_format.startswith(_PARSE_PREFIX):
         return f"e_event_{content_format.split('-', 1)[1].lower()}_id"
     raise ValueError(
         f"Unrecognized content format: {content_format}. "
-        f"Valid options: {', '.join(CONTENT_FORMATS)}, Parse-<Algorithm>"
+        f"Valid options: {', '.join(CONTENT_FORMATS)}, Prefix-<k>, "
+        f"Minhash-<tokenizer>, Parse-<Algorithm>"
     )
 
 
@@ -947,6 +1017,14 @@ def derived_columns(content_format):
         return ["e_trigrams", "e_trigrams_len"]
     if content_format in ("Sklearn", "File"):
         return []
+    if content_format.startswith(_PREFIX_PREFIX):
+        # words() emits e_words/e_words_len alongside the prefix, in one pass.
+        return [f"e_words_prefix_{_prefix_width(content_format)}", "e_words", "e_words_len"]
+    if content_format.startswith(_MINHASH_PREFIX):
+        # minhash() builds the token column it reads, so that comes too.
+        tokenizer, rows, seed = _minhash_config(content_format)
+        token_column = EventLogEnhancer.MINHASH_TOKENIZERS[tokenizer]
+        return [_minhash_column(tokenizer, rows, seed), token_column, f"{token_column}_len"]
     if content_format.startswith(_PARSE_PREFIX):
         parser = content_format.split("-", 1)[1].lower()
         return [
@@ -985,6 +1063,13 @@ def prepare_content(df, mask, content_format):
         return df, "file_name"
     if content_format == "Sklearn":
         return df, field
+    if content_format.startswith(_PREFIX_PREFIX):
+        width = _prefix_width(content_format)
+        return enhancer.words(field, prefixes=[width]), f"e_words_prefix_{width}"
+    if content_format.startswith(_MINHASH_PREFIX):
+        tokenizer, rows, seed = _minhash_config(content_format)
+        return (enhancer.minhash(field, tokenizer=tokenizer, rows=rows, seed=seed),
+                _minhash_column(tokenizer, rows, seed))
     if content_format.startswith(_PARSE_PREFIX):
         parse_type = content_format.split("-", 1)[1].lower()
         method_name = f"parse_{parse_type}"
@@ -1000,7 +1085,8 @@ def prepare_content(df, mask, content_format):
         return method(field), f"e_event_{parse_type}_id"
     raise ValueError(
         f"Unrecognized content format: {content_format}. "
-        f"Valid options: {', '.join(CONTENT_FORMATS)}, Parse-<Algorithm>"
+        f"Valid options: {', '.join(CONTENT_FORMATS)}, Prefix-<k>, "
+        f"Minhash-<tokenizer>, Parse-<Algorithm>"
     )
 
 

--- a/loglead/enhancers/eventlog.py
+++ b/loglead/enhancers/eventlog.py
@@ -39,21 +39,47 @@ class EventLogEnhancer:
             raise ValueError(f"Missing prerequisites for enrichment: {', '.join(prerequisites)}")
 
     # Function-based enricher to split messages into words
-    def words(self, column="m_message"):
+    def words(self, column="m_message", prefixes=None, reparse=False):
+        """Split messages into words as ``e_words``, with optional prefix columns.
+
+        :param prefixes: iterable of word counts. Each ``k`` adds
+            ``e_words_prefix_<k>``, the first k words joined by a space, built in
+            the same pass as ``e_words``.
+        :param reparse: recompute even when the output columns already exist.
+            Without it this short-circuits on column name alone, so a second call
+            naming a different ``column`` silently returns the first result.
+        """
         self._handle_prerequisites([column])
-        if "e_words" not in self.df.columns:
-            self.df = self.df.with_columns(pl.col(column).str.split(by=" ").alias("e_words"))
-            self.df = self.df.with_columns(
-                e_words_len = pl.col("e_words").list.len(),
+        prefixes = sorted({int(k) for k in prefixes}) if prefixes else []
+        if any(k < 1 for k in prefixes):
+            raise ValueError(f"prefixes must be >= 1, got {prefixes}")
+
+        need_words = reparse or "e_words" not in self.df.columns
+        need_prefix = [k for k in prefixes
+                       if reparse or f"e_words_prefix_{k}" not in self.df.columns]
+        if not need_words and not need_prefix:
+            return self.df
+
+        split = pl.col(column).str.split(by=" ")
+        exprs = []
+        if need_words:
+            exprs += [split.alias("e_words"), split.list.len().alias("e_words_len")]
+        for k in need_prefix:
+            # splitn stops after k+1 fields. Slicing e_words instead would tokenize
+            # the whole line first, which measures slower for the same result.
+            parts = pl.col(column).str.splitn(" ", k + 1)
+            exprs.append(
+                pl.concat_str([parts.struct.field(f"field_{i}") for i in range(k)],
+                              separator=" ", ignore_nulls=True)
+                .alias(f"e_words_prefix_{k}")
             )
-        else:
-            print("e_words already found")
+        self.df = self.df.with_columns(exprs)
         return self.df
 
     # Function-based enricher to extract alphanumeric tokens from messages
-    def alphanumerics(self, column="m_message"):
+    def alphanumerics(self, column="m_message", reparse=False):
         self._handle_prerequisites([column])
-        if "e_alphanumerics" not in self.df.columns:
+        if reparse or "e_alphanumerics" not in self.df.columns:
             self.df = self.df.with_columns(
                 pl.col(column).str.extract_all(r"[a-zA-Z\d]+").alias("e_alphanumerics")
             )
@@ -62,28 +88,17 @@ class EventLogEnhancer:
             )
         return self.df
 
-    # Function-based enricher to create trigrams from messages
-    # Trigrams enrichment is slow 1M lines in 40s.
-    # Trigram flag to be removed after this is fixed.
-    # https://github.com/pola-rs/polars/issues/10833
-    # https://github.com/pola-rs/polars/issues/10890
-    def old_trigrams(self, column="m_message"):
-        self._handle_prerequisites([column])
-        if "e_trigrams" not in self.df.columns:
-            self.df = self.df.with_columns(
-                pl.col(column).map_elements(
-                    lambda mes: self._create_cngram(message=mes, ngram=3), return_dtype=pl.List(pl.Utf8)).alias("e_trigrams")
-            )
-            self.df = self.df.with_columns(
-                e_trigrams_len = pl.col("e_trigrams").list.len()
-            )
-        return self.df
+    # Function-based enricher to create character trigrams from messages
+    def trigrams(self, column="m_message", reparse=False):
+        """Character trigrams of ``column``, as ``e_trigrams``.
 
-    def trigrams(self, column="m_message"):
-        """
-        This one runs fast three char splits with extract_all at 3 different positions
-        which results in same trigrams as above. They are not arranged, but this is 
-        much faster. These use the same "e_trigrams" column name.
+        Runs three char splits with extract_all at 3 different positions. The
+        trigrams come out unordered, but this is far faster than building them
+        per row in Python.
+
+        :param reparse: recompute even when ``e_trigrams`` already exists.
+            Without it this short-circuits on column name alone, so a second call
+            naming a different ``column`` silently returns the first result.
         """
         def extract_trigrams(text_column: str, start_pos: int) -> pl.Expr:
             return (
@@ -92,7 +107,7 @@ class EventLogEnhancer:
                 .str.extract_all(r'.{3}')
             )
         self._handle_prerequisites([column])
-        if "e_trigrams" not in self.df.columns:
+        if reparse or "e_trigrams" not in self.df.columns:
             trigrams_pos0 = extract_trigrams(column, 0)
             trigrams_pos1 = extract_trigrams(column, 1)
             trigrams_pos2 = extract_trigrams(column, 2)
@@ -106,11 +121,66 @@ class EventLogEnhancer:
 
         return self.df
 
-    @staticmethod
-    def _create_cngram(message, ngram=3):
-        if ngram <= 0:
-            return []
-        return [message[i:i + ngram] for i in range(len(message) - ngram + 1)]
+    #: Minhash tokenizer name -> the token column it reads.
+    MINHASH_TOKENIZERS = {"3gram": "e_trigrams", "words": "e_words"}
+    #TODO 3gram and e_trigrams should be the same WTF.
+    # Function-based enricher to bucket look-alike lines by a minhash signature
+    def minhash(self, column="m_message", tokenizer="3gram", rows=4, seed=0, reparse=False):
+        """Minhash signature of ``column``, as ``e_minhash_<tokenizer>_r<rows>_s<seed>``.
+
+        One band of ``rows`` min-hashes over the line's token set, joined into a
+        single string. Two lines get the same signature with probability
+        ``J ** rows`` for Jaccard similarity ``J``, so identical lines always
+        collide and near-duplicates collide often -- the column is a bucket key,
+        not a distance.
+
+        :param tokenizer: ``"3gram"`` reads ``e_trigrams``, ``"words"`` reads
+            ``e_words``. Whichever it needs is built first, from ``column``.
+        :param rows: min-hashes per signature. More rows means fewer collisions.
+        :param seed: base hash seed. Signatures built with different seeds, row
+            counts or tokenizers are not comparable, which is why all three are
+            in the column name.
+        :param reparse: recompute even when the output column already exists,
+            and rebuild the token column it reads.
+        """
+        token_column = self.MINHASH_TOKENIZERS.get(tokenizer)
+        if token_column is None:
+            raise ValueError(
+                f"Unknown minhash tokenizer {tokenizer!r}. "
+                f"Valid options: {sorted(self.MINHASH_TOKENIZERS)}"
+            )
+        if rows < 1:
+            raise ValueError(f"rows must be >= 1, got {rows}")
+        self._handle_prerequisites([column])
+
+        output = f"e_minhash_{tokenizer}_r{rows}_s{seed}"
+        if not reparse and output in self.df.columns:
+            return self.df
+
+        if tokenizer == "3gram":
+            self.trigrams(column, reparse=reparse)
+        else:
+            self.words(column, reparse=reparse)
+
+        # K permutations are K hash seeds, each reduced with min() over the
+        # row's tokens: one explode and one group_by, no Python loop over rows.
+        # A line with no tokens explodes to a null, which hashes to a value like
+        # any other -- so empty lines share a bucket rather than going null.
+        signature = (
+            self.df.select(token_column)
+            .with_row_index("_minhash_row")
+            .explode(token_column)
+            .group_by("_minhash_row")
+            .agg([pl.col(token_column).hash(seed=seed + j).min().alias(f"_h{j}")
+                  for j in range(rows)])
+            .sort("_minhash_row")
+            .select(
+                pl.concat_str([pl.col(f"_h{j}").cast(pl.Utf8) for j in range(rows)],
+                              separator="-").alias(output)
+            )
+        )
+        self.df = self.df.with_columns(signature.to_series())
+        return self.df
 
     # Enrich with drain parsing results
     def parse_drain(self, field = "e_message_normalized", drain_masking=False, reparse=False, templates=False, persistence=False):
@@ -407,9 +477,12 @@ class EventLogEnhancer:
             self.df = pl.concat([self.df, df_new], how="horizontal")
         return self.df
 
-    def create_neural_emb(self, field="e_message_normalized"):
+    def create_neural_emb(self, field="e_message_normalized", reparse=False):
         self._handle_prerequisites([field])
-        if "e_bert_emb" not in self.df.columns:
+        if reparse or "e_bert_emb" not in self.df.columns:
+            if "e_bert_emb" in self.df.columns:
+                # hstack appends a duplicate name rather than replacing the column
+                self.df = self.df.drop("e_bert_emb")
             from loglead.parsers import BertEmbeddings
             #if "e_message_normalized" not in self.df.columns:
             #    self.normalize()
@@ -425,9 +498,9 @@ class EventLogEnhancer:
             self.df = self.df.hstack(bert_emb_col_df)
         return self.df
 
-    def length(self, column="m_message"):
-        self._handle_prerequisites(["m_message"])
-        if "e_chars_len" not in self.df.columns:
+    def length(self, column="m_message", reparse=False):
+        self._handle_prerequisites([column])
+        if reparse or "e_chars_len" not in self.df.columns:
             self.df = self.df.with_columns(
                 e_chars_len=pl.col(column).str.len_chars(),
                 e_lines_len=pl.col(column).str.count_matches(r"(\n|\r|\r\n)"),

--- a/loglead/mcp/server.py
+++ b/loglead/mcp/server.py
@@ -1306,6 +1306,17 @@ def distance_file_content(
     )
 
 
+_LINE_BUCKET_NOTE = (
+    "Each row is a group of look-alike lines, not a line. target_only=true "
+    "means no comparison log folder has any line in that bucket, so those are "
+    "the point anomalies; a large delta_pct on a shared bucket is a frequency "
+    "shift, which a line-by-line comparison cannot see at all. Rank by the "
+    "coarsest resolution that flags a bucket: a coarse resolution absorbs benign "
+    "variation and so has a lower false-positive floor, but is blind to "
+    "anomalies that differ only late in the line."
+)
+
+
 @tool
 def distance_line_content(
     session_id: str,
@@ -1313,58 +1324,84 @@ def distance_line_content(
     comparison_folders: FolderSelector = "ALL",
     target_files: FileSelector = "ALL",
     mask: bool = True,
-    max_changed_lines: int = 40,
+    resolutions: Optional[Sequence[str]] = None,
+    max_rows: int = 25,
 ) -> dict:
-    """Line-by-line diff of a file between the target log folder and others.
+    """Which kinds of line does this file have that the other do not have?
+    Groups / clusters lines by their content. Allows two use cases
+    1) Comparing target vs comparison on group frequencies which indicate 
+    execution pattern anomalies  2) Finding groups that mainly appear in target 
+    which can indicate point anomalies, but also groups that mainly appear in 
+    comparison which can indicate point anomaly of missing an excution. 
 
-    Unlike the other distance_* tools, this does not vectorize and score --
-    it runs a text diff, which only reads well between two specific log
-    folders. Use it once the other measures have narrowed things down to a
-    small comparison set, not as a first pass over many log folders.
-
-    Returns change counts per comparison plus a sample of the differing lines;
-    the complete diff for each pair is written to disk.
+    Grouping can be done at different resolutions, e.g. prefix token match
+    (fastest), exact masked line (also fast, but needs accurate masking), or
+    minhash over character 3-grams (slowest, but tolerates inaccurate masking).
 
     Args:
         session_id: Handle from open_log_root.
         target_folder: Exact log folder name to investigate.
         comparison_folders: "ALL", a list, an int N, or a "Prefix*" wildcard.
-            One diff is produced per comparison log folder per file, so narrow this.
+            These are pooled into one baseline, so widening this makes
+            target_only stricter rather than producing more output.
         target_files: "ALL", a list of file names, an int N, or a "name*" wildcard.
-        mask: Diff the masked text, which hides timestamp and id churn.
-        max_changed_lines: Changed lines sampled per pair.
+        mask: Must be true. On raw lines nearly every line is distinct, so
+            almost all of them land in target-only buckets and say nothing.
+        resolutions: Leave unset for ["Prefix-3", "Exact"], coarse first. Both
+            are near-free, so the pair runs on every call. Also accepts:
+            "Prefix-<k>" for any k;
+            "Minhash-3gram" or "Minhash-words" to group  look-alike lines by a
+            minhash signature, which tolerates masking that missed a parameter
+            and, unlike Prefix-<k>, is not blind to a late-line anomaly.
+             "Minhash-words" costs about 2x and "Minhash-3gram" about 10x,
+            so run them as a second pass over what the default flagged. Takes
+            optional "-r<rows>" (more rows, fewer collisions; default 4) and
+            "-s<seed>" (default 0) suffixes, e.g. "Minhash-3gram-r6-s7";
+            "Parse-<Algorithm>" Parse-Drain, Parse-Tip to bucket by mined template.
+        max_rows: Rows returned inline, target-only buckets first and largest
+            first within that.
     """
     session = STORE.get(session_id)
-    diffs = distance.distance_line_content(
-        session.df, target_folder, comparison_folders, target_files, mask
+    resolutions = list(resolutions) if resolutions else list(distance.DEFAULT_RESOLUTIONS)
+    # ensure_content materializes a resolution column over the whole log root,
+    # so check there is something to compare before paying for it -- otherwise a
+    # log root whose folders share no file name pays in full for an empty result.
+    comparable = distance.comparable_files(
+        session.df, target_folder, comparison_folders, target_files
     )
+    # Per resolution, so the session's own staleness guard drops a derived
+    # column that was built from a different source column.
+    for resolution in (resolutions if comparable else []):
+        session.ensure_content(mask, distance._resolution_format(resolution))
 
-    comparisons = []
-    for file_name, other_folder, diff_df in diffs:
+    per_file, summary, session.df = distance.distance_line_content(
+        session.df, target_folder, comparison_folders, target_files, mask, resolutions,
+    )
+    session.flush()
+
+    files, frames = [], []
+    for _, file_name, bucket_df in per_file:
         artifact = _write(
-            session, diff_df, "dis", 4, target_folder=target_folder,
-            comparison_folder=other_folder, mask=mask, file=file_name,
+            session, bucket_df, "dis", 4, target_folder=target_folder,
+            comparison_folder="Many", mask=mask, file=file_name,
         )
-        changed = diff_df.filter(pl.col("difference").is_in(["-", "+"]))
-        comparisons.append({
+        files.append({
             "file_name": file_name,
-            "comparison_folder": other_folder,
-            "summary": distance.summarize_diff(diff_df),
-            "changed_sample": changed.head(max_changed_lines).to_dicts(),
-            "changed_truncated": changed.height > max_changed_lines,
+            "resolutions": distance.summarize_line_buckets(bucket_df).to_dicts(),
             "artifact": artifact,
         })
+        frames.append(bucket_df.with_columns(pl.lit(file_name).alias("file_name")))
 
-    return {
-        "session_id": session_id,
-        "analysis": "distance_line_content",
-        "level": 4,
-        "params": {"target_folder": target_folder, "comparison_folders": comparison_folders,
-                   "target_files": target_files, "mask": mask},
-        "n_comparisons": len(comparisons),
-        "comparisons": comparisons,
-        "notes": ["'-' is present only in the target log folder, '+' only in the comparison."],
-    }
+    buckets = pl.concat(frames, how="vertical_relaxed") if frames else pl.DataFrame()
+    return formatting.result(
+        session, "distance_line_content", 4,
+        {"target_folder": target_folder, "comparison_folders": comparison_folders,
+         "target_files": target_files, "mask": mask, "resolutions": resolutions},
+        buckets, None, max_rows, sort_by=["target_only", "target_n"],
+        notes=[_LINE_BUCKET_NOTE],
+        extra={"n_files": len(files), "files": files,
+               "summary": summary.to_dicts() if summary.height else []},
+    )
 
 
 # --------------------------------------------------------------------------- #

--- a/loglead/mcp/session.py
+++ b/loglead/mcp/session.py
@@ -270,9 +270,14 @@ class Session:
             )
 
         field = "e_message_normalized" if mask else "m_message"
-        target = log_root.content_column(mask, content_format)
         derived = log_root.derived_columns(content_format)
-        if derived and self.content_source.get(target, field) != field:
+        # Every derived column, not just the one the format is named for. A
+        # format can build others as a side effect -- Prefix-<k> also produces
+        # e_words -- and a column whose source was never recorded is
+        # indistinguishable from one built from the current source, so it would
+        # be handed back silently. Checking the whole set is also what makes
+        # recording the whole set below truthful: they are all rebuilt together.
+        if derived and any(self.content_source.get(col, field) != field for col in derived):
             stale = [col for col in derived if col in self.df.columns]
             self.df = self.df.drop(stale)
             self.vocabularies.clear()
@@ -283,8 +288,8 @@ class Session:
         if set(df.columns) != before:
             self.df = df
             self._dirty = True
-        if derived:
-            self.content_source[target] = field
+        for col in derived:
+            self.content_source[col] = field
         return self.df, resolved_field
 
     def flush(self):
@@ -527,14 +532,25 @@ class SessionStore:
             # bookkeeping ensure_content keeps. A column whose source was never
             # recorded is treated as masked-derived: dropping one that was not
             # only costs a recompute, while keeping one that was is a wrong answer.
-            formats = ["Words", "3grams"] + [f"Parse-{parser}" for parser in session.parsers]
+            # Prefix widths and minhash configurations are not tracked in session
+            # state, so they are read back off the columns themselves.
+            widths = sorted({column.rsplit("_", 1)[1] for column in session.df.columns
+                             if column.startswith("e_words_prefix_")})
+            formats = (["Words", "3grams"]
+                       + [f"Prefix-{width}" for width in widths]
+                       + log_root.minhash_formats(session.df.columns)
+                       + [f"Parse-{parser}" for parser in session.parsers])
             for content_format in formats:
                 target = log_root.content_column(True, content_format)
                 if session.content_source.get(target) == "m_message":
                     continue
-                dropped.extend(column for column in log_root.derived_columns(content_format)
-                               if column in session.df.columns)
-                session.content_source.pop(target, None)
+                derived = log_root.derived_columns(content_format)
+                # Formats overlap -- Words and Prefix-<k> share e_words -- and
+                # drop() rejects a repeated name.
+                dropped.extend(column for column in derived
+                               if column in session.df.columns and column not in dropped)
+                for column in derived:
+                    session.content_source.pop(column, None)
             df = session.df.drop(dropped) if dropped else session.df
             session.df = EventLogEnhancer(df).normalize(regexs=resolved)
 

--- a/tests/mcp/PERFORMANCE.md
+++ b/tests/mcp/PERFORMANCE.md
@@ -77,9 +77,9 @@ Tables A1-A4 are **cold** (first call, nothing cached). Tables B1-B4 are the sam
 | distance_file_content | hadoop_renamed | 0.775 | 1.621 | 8.271 | 16.9 |
 | distance_file_content | hdfs_balanced_5k | 0.019 | 0.025 | 0.021 | 0.023 |
 | distance_file_content | bgl_split_10 | 0.034 | 0.052 | 0.167 | 0.275 |
-| distance_line_content | hadoop_renamed | 1.388 | 0.102 | 0.359 | 1.284 |
-| distance_line_content | hdfs_balanced_5k | 0.724 | 1.588 | 8.571 | 16.2 |
-| distance_line_content | bgl_split_10 | 0.089 | 0.117 | 0.246 | 0.327 |
+| distance_line_content | hadoop_renamed | 0.158 | 0.237 | 0.255 | 0.734 |
+| distance_line_content | hdfs_balanced_5k | 0.038 | 0.050 | 0.076 | 0.102 |
+| distance_line_content | bgl_split_10 | 0.071 | 0.096 | 0.283 | 0.536 |
 
 ## Table A3 -- Anomaly tools
 
@@ -177,9 +177,9 @@ Tables A1-A4 are **cold** (first call, nothing cached). Tables B1-B4 are the sam
 | distance_file_content | hadoop_renamed | 0.912 | 1.665 | 7.704 | 16.7 |
 | distance_file_content | hdfs_balanced_5k | 0.015 | 0.019 | 0.019 | 0.022 |
 | distance_file_content | bgl_split_10 | 0.032 | 0.050 | 0.162 | 0.273 |
-| distance_line_content | hadoop_renamed | 1.280 | 0.110 | 0.404 | 1.131 |
-| distance_line_content | hdfs_balanced_5k | 0.761 | 1.558 | 8.185 | 16.6 |
-| distance_line_content | bgl_split_10 | 0.108 | 0.140 | 0.250 | 0.378 |
+| distance_line_content | hadoop_renamed | 0.158 | 0.228 | 0.220 | 0.207 |
+| distance_line_content | hdfs_balanced_5k | 0.041 | 0.045 | 0.065 | 0.078 |
+| distance_line_content | bgl_split_10 | 0.074 | 0.104 | 0.269 | 0.499 |
 
 ## Table B3 -- Anomaly tools
 
@@ -220,7 +220,7 @@ Tables A1-A4 are **cold** (first call, nothing cached). Tables B1-B4 are the sam
 
 # Detailed breakdowns (per detector / per measure)
 
-The tables above run every anomaly tool with all four detectors, and `distance_folder_content`/`distance_file_content` with all four measures, at once. Part C/D below break the same figure down per detector / per measure run in isolation (`detectors=["<name>"]` / `measures=["<name>"]`), so the cost of narrowing either is visible on its own rather than folded into the combined call. `distance_folder_filename` (jaccard/overlap distance over file names only) and `distance_line_content` (a text diff, no measures) are not broken down further -- neither computes multiple vectorized measures in one pass.
+The tables above run every anomaly tool with all four detectors, and `distance_folder_content`/`distance_file_content` with all four measures, at once. Part C/D below break the same figure down per detector / per measure run in isolation (`detectors=["<name>"]` / `measures=["<name>"]`), so the cost of narrowing either is visible on its own rather than folded into the combined call. `distance_folder_filename` (jaccard/overlap distance over file names only) and `distance_line_content` (bucket histograms, which take resolutions rather than measures) are not broken down further -- neither computes multiple vectorized measures in one pass.
 
 # Part C -- cold (first call)
 

--- a/tests/mcp/PERF_MEMORY.md
+++ b/tests/mcp/PERF_MEMORY.md
@@ -97,9 +97,9 @@ the cell directory to re-measure the grid from scratch.
 | distance_file_content | hadoop_renamed | 0.424 | 0.470 | 1.08 | 1.54 |
 | distance_file_content | hdfs_balanced_5k | 0.584 | 0.613 | 0.837 | 1.10 |
 | distance_file_content | bgl_split_10 | 1.18 | 1.64 | 5.18 | 10.16 |
-| distance_line_content | hadoop_renamed | 0.435 | 0.488 | 1.10 | 1.56 |
-| distance_line_content | hdfs_balanced_5k | 0.585 | 0.617 | 0.852 | 1.11 |
-| distance_line_content | bgl_split_10 | 1.18 | 1.65 | 5.26 | 10.20 |
+| distance_line_content | hadoop_renamed | 0.334 | 0.362 | 0.458 | 0.909 |
+| distance_line_content | hdfs_balanced_5k | 0.325 | 0.334 | 0.384 | 0.434 |
+| distance_line_content | bgl_split_10 | 0.462 | 0.601 | 1.61 | 2.93 |
 
 ## Table A3 -- Anomaly tools
 
@@ -197,9 +197,9 @@ the cell directory to re-measure the grid from scratch.
 | distance_file_content | hadoop_renamed | 0.432 | 0.484 | 1.09 | 1.56 |
 | distance_file_content | hdfs_balanced_5k | 0.584 | 0.613 | 0.837 | 1.10 |
 | distance_file_content | bgl_split_10 | 1.18 | 1.65 | 5.26 | 10.20 |
-| distance_line_content | hadoop_renamed | 0.438 | 0.500 | 1.11 | 1.56 |
-| distance_line_content | hdfs_balanced_5k | 0.587 | 0.620 | 0.867 | 1.11 |
-| distance_line_content | bgl_split_10 | 1.18 | 1.65 | 5.26 | 10.20 |
+| distance_line_content | hadoop_renamed | 0.336 | 0.389 | 0.492 | 0.935 |
+| distance_line_content | hdfs_balanced_5k | 0.331 | 0.341 | 0.422 | 0.445 |
+| distance_line_content | bgl_split_10 | 0.463 | 0.606 | 1.63 | 2.95 |
 
 ## Table B3 -- Anomaly tools
 
@@ -240,7 +240,7 @@ the cell directory to re-measure the grid from scratch.
 
 # Detailed breakdowns (per detector / per measure)
 
-The tables above run every anomaly tool with all four detectors, and `distance_folder_content`/`distance_file_content` with all four measures, at once. Part C/D below break the same figure down per detector / per measure run in isolation (`detectors=["<name>"]` / `measures=["<name>"]`), so the cost of narrowing either is visible on its own rather than folded into the combined call. `distance_folder_filename` (jaccard/overlap distance over file names only) and `distance_line_content` (a text diff, no measures) are not broken down further -- neither computes multiple vectorized measures in one pass.
+The tables above run every anomaly tool with all four detectors, and `distance_folder_content`/`distance_file_content` with all four measures, at once. Part C/D below break the same figure down per detector / per measure run in isolation (`detectors=["<name>"]` / `measures=["<name>"]`), so the cost of narrowing either is visible on its own rather than folded into the combined call. `distance_folder_filename` (jaccard/overlap distance over file names only) and `distance_line_content` (bucket histograms, which take resolutions rather than measures) are not broken down further -- neither computes multiple vectorized measures in one pass.
 
 # Part C -- cold (first call)
 

--- a/tests/mcp/benchmark.py
+++ b/tests/mcp/benchmark.py
@@ -434,8 +434,9 @@ GRID_TABLE_TITLES = (("aux", "Auxiliary tools"), ("distance", "Distance tools"),
 #: / ``distance.DEFAULT_MEASURES`` rather than hardcoded, so a detector or
 #: measure added there shows up here without a second edit.
 #: ``distance_folder_filename`` (jaccard/overlap distance over file names only)
-#: and ``distance_line_content`` (a text diff, no measures) have nothing to
-#: isolate -- neither computes multiple vectorized measures in one pass.
+#: and ``distance_line_content`` (bucket histograms, which take resolutions
+#: rather than measures) have nothing to isolate -- neither computes multiple
+#: vectorized measures in one pass.
 DETAIL_ANOMALY_TOOLS = ("anomaly_folder_filename", "anomaly_folder_content",
                         "anomaly_file_content", "anomaly_line_content")
 DETAIL_DISTANCE_TOOLS = ("distance_folder_content", "distance_file_content")
@@ -954,8 +955,9 @@ _DETAIL_INTRO = [
     "`measures=[\"<name>\"]`), so the cost of narrowing either is visible on "
     "its own rather than folded into the combined call. `distance_folder_filename` "
     "(jaccard/overlap distance over file names only) and `distance_line_content` "
-    "(a text diff, no measures) are not broken down further -- neither computes "
-    "multiple vectorized measures in one pass.",
+    "(bucket histograms, which take resolutions rather than measures) are not "
+    "broken down further -- neither computes multiple vectorized measures in "
+    "one pass.",
 ]
 
 

--- a/tests/mcp/server.py
+++ b/tests/mcp/server.py
@@ -719,19 +719,53 @@ def stage_hadoop_distance(check, session_id, target, file_name):
 
     l4 = timed("distance_line_content", server.distance_line_content,
                session_id, target, comparison_folders=2, target_files=[file_name],
-               max_changed_lines=3)
-    check.eq("one diff per (file, comparison folder)", l4["n_comparisons"], 2)
-    comparison = l4["comparisons"][0]
-    check.eq("the diff summary adds up",
-             comparison["summary"]["unchanged"] + comparison["summary"]["only_in_target"]
-             + comparison["summary"]["only_in_comparison"] + comparison["summary"]["hints"],
-             comparison["summary"]["total"])
-    check.ok("the changed sample is capped", len(comparison["changed_sample"]) <= 3)
-    check.ok("sampled lines are marked - or +",
-             all(line["difference"] in ("-", "+") for line in comparison["changed_sample"]))
-    check.ok("each diff was written out", os.path.isfile(comparison["artifact"]))
-    check.ok("the note explains the markers",
-             any("only in the target" in note for note in l4["notes"]))
+               max_rows=5)
+    check.eq("one entry for the one target file", l4["n_files"], 1)
+    entry = l4["files"][0]
+    check.eq("both default resolutions ran", len(entry["resolutions"]), 2)
+    check.eq("coarse resolution first",
+             [row["resolution"] for row in entry["resolutions"]], ["Prefix-3", "Exact"])
+    check.ok("a coarse bucket set is smaller than an exact one",
+             entry["resolutions"][0]["buckets"] <= entry["resolutions"][1]["buckets"],
+             f"{entry['resolutions'][0]['buckets']} <= {entry['resolutions'][1]['buckets']}")
+    check.ok("target-only buckets never outnumber all buckets",
+             all(row["target_only_buckets"] <= row["buckets"]
+                 for row in entry["resolutions"]))
+    check.ok("the bucket table was written out", os.path.isfile(entry["artifact"]))
+    check.ok("rows are buckets carrying a readable line",
+             all("representative_line" in row and "target_only" in row
+                 for row in l4["rows"]), str(list(l4["rows"][0])))
+    check.ok("target-only buckets sort first",
+             [row["target_only"] for row in l4["rows"]]
+             == sorted((row["target_only"] for row in l4["rows"]), reverse=True))
+    check.ok("summary carries the distribution distances",
+             all("js_divergence" in row and "target_only_mass" in row
+                 for row in l4["summary"]))
+    check.ok("the note explains what a bucket is",
+             any("look-alike lines" in note for note in l4["notes"]),
+             str(l4["notes"]))
+    check.raises("mask=False is refused", ValueError,
+                 server.distance_line_content, session_id, target,
+                 comparison_folders=2, target_files=[file_name], mask=False)
+
+    l4m = timed("distance_line_content (minhash)", server.distance_line_content,
+                session_id, target, comparison_folders=2, target_files=[file_name],
+                resolutions=["Minhash-3gram-r4", "Exact"], max_rows=5)
+    minhash_entry = l4m["files"][0]
+    check.eq("the opt-in minhash resolution ran",
+             [row["resolution"] for row in minhash_entry["resolutions"]],
+             ["Minhash-3gram-r4", "Exact"])
+    # A signature is a function of the masked line, so identical lines always
+    # collide and minhash can only ever merge buckets Exact kept apart.
+    check.ok("minhash never splits what Exact groups",
+             minhash_entry["resolutions"][0]["buckets"]
+             <= minhash_entry["resolutions"][1]["buckets"],
+             f"{minhash_entry['resolutions'][0]['buckets']} <= "
+             f"{minhash_entry['resolutions'][1]['buckets']}")
+    check.raises("an unknown minhash tokenizer is refused", ValueError,
+                 server.distance_line_content, session_id, target,
+                 comparison_folders=2, target_files=[file_name],
+                 resolutions=["Minhash-bigram"])
     return l2
 
 


### PR DESCRIPTION
Removing the diff the from distance_line_content function and replacing it with line bucketing / clustering / grouping. This allows the "distance" behavior as for each line we know the bucket it belongs and can compare with similar lines in the comparison. Still this is somewhat different on what one might expect. Lets see we might later change this feature to a new function name and disable distance_line_content althogher although that would break the nice symmetry.  